### PR TITLE
[Fix] the EFU command port should not be in use, but 8888 is often used

### DIFF
--- a/image.def
+++ b/image.def
@@ -14,7 +14,7 @@ splitrun-nexus.sh /usr/bin/splitrun-nexus
 
 %post
 apt -y update
-apt -y install git python3-packaging python3-yaml uuid
+apt -y install git python3-packaging python3-yaml python3-ephemeral-port-reserve uuid
 python3 -m pip install --break-system-packages "mccode-plumber=={{ plumber_version }}"
 chmod +x /usr/bin/launch-writer
 chmod +x /usr/bin/launch-forwarder

--- a/splitrun-nexus.sh
+++ b/splitrun-nexus.sh
@@ -31,7 +31,7 @@ case "${lower_instrument}" in
     { [ -z "${EFU_CALIB+x}" ] || [ -z "${EFU_CALIB}" ]; } && efu_calib="/etc/efu/bifrost/configs/bifrostnullcalib.json" || efu_calib="${EFU_CALIB}"
     { [ -z "${EFU_CMD_PORT+x}" ] || [ -z "${EFU_CMD_PORT}" ]; } && efu_cmd_port="$(ephemeral-port-reserve)" || efu_cmd_port="${EFU_CMD_PORT}"
     # Also use an ephemeral port number for the EFU UDP receiving port?
-    EFU_COMMAND="bifrost -f ${efu_config} --calibration ${efu_calib}" --cmdport ${efu_cmd_port}
+    EFU_COMMAND="bifrost -f ${efu_config} --calibration ${efu_calib} --cmdport ${efu_cmd_port}"
     ;;
   cspec | dream | freia | loki | miracles | nmx | trex) 
     echo "Untested splitrun for ${INSTRUMENT} -- setting EFU configuration paremeters is necessary"

--- a/splitrun-nexus.sh
+++ b/splitrun-nexus.sh
@@ -29,7 +29,9 @@ case "${lower_instrument}" in
   bifrost)
     { [ -z "${EFU_CONFIG+x}" ] || [ -z "${EFU_CONFIG}" ]; } && efu_config="/etc/efu/bifrost/configs/bifrost.json" || efu_config="${EFU_CONFIG}"
     { [ -z "${EFU_CALIB+x}" ] || [ -z "${EFU_CALIB}" ]; } && efu_calib="/etc/efu/bifrost/configs/bifrostnullcalib.json" || efu_calib="${EFU_CALIB}"
-    EFU_COMMAND="bifrost -f ${efu_config} --calibration ${efu_calib}"
+    { [ -z "${EFU_CMD_PORT+x}" ] || [ -z "${EFU_CMD_PORT}" ]; } && efu_cmd_port="$(ephemeral-port-reserve)" || efu_cmd_port="${EFU_CMD_PORT}"
+    # Also use an ephemeral port number for the EFU UDP receiving port?
+    EFU_COMMAND="bifrost -f ${efu_config} --calibration ${efu_calib}" --cmdport ${efu_cmd_port}
     ;;
   cspec | dream | freia | loki | miracles | nmx | trex) 
     echo "Untested splitrun for ${INSTRUMENT} -- setting EFU configuration paremeters is necessary"


### PR DESCRIPTION
A call to [ephemeral-port-reserve](https://pypi.org/project/ephemeral-port-reserve/) ensures that a command port is specified that is not in use.
Since the EFU is run in concert with `splitrun-nexus` not knowing its command port is unlikely to be a big problem.